### PR TITLE
Update crate version to 0.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0 (2022-10-09)
+
+* In `untagged`, genericize `TypeReg` and `TypeMap`, so stored type may have different trait bounds.
+* `TypeMap` defaults to storing `BoxDt`, which has `Clone`, serialization, and optionally `Debug` constraints.
+* `TypeMap` may store `BoxDtDisplay`, which adds the `Display` constraint.
+* ***Breaking:*** Previously, `Box<dyn DataType>` may be downcasted to `T` through `data.downcast_ref::<T>()`. Now, one needs to use `BoxDataTypeDowncast::<T>::downcast_ref(box_dt)`;
+
 ## 0.3.1 (2022-09-03)
 
 * Implement `Debug` for `TypeReg`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type_reg"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2021"
 description = "Serializable map of any type."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ all-features = true
 
 [dependencies]
 downcast-rs = "1.2.0"
-dyn-clone = "1.0.4"
-erased-serde = "0.3.18"
-indexmap = { version = "1.8.0", optional = true }
-serde = { version = "1.0.136", features = ["derive"] }
+dyn-clone = "1.0.9"
+erased-serde = "0.3.23"
+indexmap = { version = "1.9.1", optional = true }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_tagged = "0.2.0"
 
 [dev-dependencies]
-serde_yaml = "0.9.11"
+serde_yaml = "0.9.13"
 
 [[example]]
 name = "tagged_serialize"

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ This library provides a map that can store any serializable type, and retrieve i
 Add the following to `Cargo.toml`
 
 ```toml
-type_reg = { version = "0.3.1", features = ["tagged"] }
-type_reg = { version = "0.3.1", features = ["untagged"] }
+type_reg = { version = "0.4.0", features = ["tagged"] }
+type_reg = { version = "0.4.0", features = ["untagged"] }
 
 # Values must impl Debug, and TypeMap's Debug impl will
 # print the debug string of each value.
-type_reg = { version = "0.3.1", features = ["debug"] }
+type_reg = { version = "0.4.0", features = ["debug"] }
 
 # Use insertion order for TypeMap and TypeReg iteration order.
-type_reg = { version = "0.3.1", features = ["ordered"] }
+type_reg = { version = "0.4.0", features = ["ordered"] }
 ```
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,15 @@
 //! Add the following to `Cargo.toml`
 //!
 //! ```toml
-//! type_reg = { version = "0.3.1", features = ["tagged"] }
-//! type_reg = { version = "0.3.1", features = ["untagged"] }
+//! type_reg = { version = "0.4.0", features = ["tagged"] }
+//! type_reg = { version = "0.4.0", features = ["untagged"] }
 //!
 //! # Values must impl Debug, and TypeMap's Debug impl will
 //! # print the debug string of each value.
-//! type_reg = { version = "0.3.1", features = ["debug"] }
+//! type_reg = { version = "0.4.0", features = ["debug"] }
 //!
 //! # Use insertion order for TypeMap and TypeReg iteration order.
-//! type_reg = { version = "0.3.1", features = ["ordered"] }
+//! type_reg = { version = "0.4.0", features = ["ordered"] }
 //! ```
 //!
 //! ### Untagged Type Registry


### PR DESCRIPTION
This unblocks the first item in https://github.com/azriel91/peace/issues/28. Ideally we should make the same changes to the `tagged` type registry, and commonize the `Box` data types.