### PR TITLE
Separate two unrelated lifetimes to allow more use-cases

### DIFF
--- a/src/untagged/type_map_opt_visitor.rs
+++ b/src/untagged/type_map_opt_visitor.rs
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<'r: 'de, 'de, K, BoxDT> serde::de::Visitor<'de>
+impl<'r, 'de, K, BoxDT> serde::de::Visitor<'de>
     for TypeMapOptVisitor<'r, K, BoxDT, UnknownEntriesNone>
 where
     K: Clone + Eq + Hash + fmt::Debug + serde::Deserialize<'de> + 'de + 'static,
@@ -92,7 +92,7 @@ where
     }
 }
 
-impl<'r: 'de, 'de, K, BoxDT, ValueT> serde::de::Visitor<'de>
+impl<'r, 'de, K, BoxDT, ValueT> serde::de::Visitor<'de>
     for TypeMapOptVisitor<'r, K, BoxDT, BoxFnSeed<Option<ValueT>>>
 where
     K: Clone + Eq + Hash + fmt::Debug + serde::Deserialize<'de> + 'de + 'static,

--- a/src/untagged/type_map_visitor.rs
+++ b/src/untagged/type_map_visitor.rs
@@ -55,7 +55,7 @@ where
     }
 }
 
-impl<'r: 'de, 'de, K, BoxDT> serde::de::Visitor<'de>
+impl<'r, 'de, K, BoxDT> serde::de::Visitor<'de>
     for TypeMapVisitor<'r, K, BoxDT, UnknownEntriesNone>
 where
     K: Clone + Debug + Eq + Hash + serde::Deserialize<'de> + 'de + 'static,
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<'r: 'de, 'de, K, BoxDT, ValueT> serde::de::Visitor<'de>
+impl<'r, 'de, K, BoxDT, ValueT> serde::de::Visitor<'de>
     for TypeMapVisitor<'r, K, BoxDT, BoxFnSeed<ValueT>>
 where
     K: Clone + Debug + Eq + Hash + serde::Deserialize<'de> + 'de + 'static,

--- a/src/untagged/type_reg.rs
+++ b/src/untagged/type_reg.rs
@@ -215,7 +215,7 @@ where
     ///
     /// println!("{data_u32}, {data_u64}"); // prints "1, 2"
     /// ```
-    pub fn deserialize_map<'de, D, E>(&'de self, deserializer: D) -> Result<TypeMap<K, BoxDT>, E>
+    pub fn deserialize_map<'de, D, E>(&self, deserializer: D) -> Result<TypeMap<K, BoxDT>, E>
     where
         K: serde::de::Deserialize<'de> + 'de,
         D: serde::de::Deserializer<'de, Error = E>,
@@ -255,7 +255,7 @@ where
     /// assert_eq!(Some(None), data_u64);
     /// ```
     pub fn deserialize_map_opt<'de, D, E>(
-        &'de self,
+        &self,
         deserializer: D,
     ) -> Result<TypeMapOpt<K, BoxDT>, E>
     where


### PR DESCRIPTION
TypeMapVisitor has two lifetimes associated with it:

  * `'r` is the lifetime of its reference to TypeReg, the registry of types in the TypeMap.
  * `'de` is the lifetime of the source data that the deserializer is reading. This lifetime is provided to [allow for zero-copy deserialization](https://serde.rs/lifetimes.html#the-deserializerde-lifetime).

Currently it constrains `'r: 'de`, meaning the TypeReg must live at least as long as the source data. But, this is unnecessary, the TypeReg only needs to live for as long as it takes to deserialize the data. Once that data is converted into a TypeMap, the TypeReg is no longer necessary. If anything, `'de` should outlive `'r`, which is a constraint applied to the tagged version of TypeMap. I don't think that constraint is actually necessary though. These two lifetimes are entirely unrelated to each-other.

As an example, consider the case of using Serde to deserialize from a `&'static str`. In this case `'de: 'static`. With the current constraints deserialization can only happen if the TypeReg is itself static – nearly impossible in practice since it is not thread safe. So this small change enables more flexible usage.